### PR TITLE
Allow clapper library to be used standalone 

### DIFF
--- a/lib/gst/clapper/meson.build
+++ b/lib/gst/clapper/meson.build
@@ -28,6 +28,14 @@ gstclapper_headers = [
   'gstclapper-mpris.h',
   'gstclapper-gtk4-plugin.h',
 ]
+
+gstclapper_gtk4_headers = [
+  'gtk4/gstclapperglsink.h',
+  'gtk4/gstclapperglutils.h',
+  'gtk4/gstgtkutils.h',
+  'gtk4/gtkclapperglwidget.h',
+]
+
 gstclapper_defines = [
   '-DHAVE_CONFIG_H',
   '-DBUILDING_GST_CLAPPER',
@@ -102,6 +110,11 @@ gstclapper = library('gstclapper-' + api_version,
   install_dir: pkglibdir,
   dependencies: gstclapper_deps,
 )
+install_headers(gstclapper_headers, subdir: 'gst/clapper')
+install_headers(gstclapper_gtk4_headers, subdir: 'gst/clapper/gtk4')
+
+pkg = import('pkgconfig')
+pkg.generate(gstclapper, install_dir: libdir + '/pkgconfig')
 
 clapper_gir = gnome.generate_gir(gstclapper,
   sources: gstclapper_sources + gstclapper_headers,

--- a/lib/gst/clapper/meson.build
+++ b/lib/gst/clapper/meson.build
@@ -107,7 +107,7 @@ gstclapper = library('gstclapper-' + api_version,
   include_directories: [configinc, libsinc],
   version: libversion,
   install: true,
-  install_dir: pkglibdir,
+  install_dir: libdir,
   dependencies: gstclapper_deps,
 )
 install_headers(gstclapper_headers, subdir: 'gst/clapper')

--- a/lib/gst/plugin/handlers/gl/gstclapperglcontexthandler.c
+++ b/lib/gst/plugin/handlers/gl/gstclapperglcontexthandler.c
@@ -247,8 +247,8 @@ _retrieve_gl_context_on_main (GstClapperGLContextHandler *self)
       self->gst_display = (GstGLDisplay *)
           gst_gl_display_x11_new_with_display (display_ptr);
     }
-  }
 #endif
+  }
 #endif
 
 #if GST_CLAPPER_GL_CONTEXT_HANDLER_HAVE_WIN32

--- a/lib/gst/plugin/meson.build
+++ b/lib/gst/plugin/meson.build
@@ -46,6 +46,16 @@ gst_clapper_plugin_sources = [
   'gstclapperimporterloader.c',
 ]
 
+gst_clapper_plugin_headers = [
+  'gstclappercontexthandler.h',
+  'gstclapperimporter.h',
+  'gstclapperimporterloader.h',
+  'gstclapperpaintable.h',
+  'gstclappersink.h',
+  'gstgdkformats.h',
+  'gstgtkutils.h',
+]
+
 if build_gst_plugin
   clapper_plugin = library('gstclapper',
     gst_clapper_plugin_sources,
@@ -60,6 +70,9 @@ if build_gst_plugin
     include_directories: configinc,
     dependencies: gst_clapper_plugin_deps,
   )
+  install_headers(gst_clapper_plugin_headers, subdir: 'gst/plugin')
+  pkg = import('pkgconfig')
+  pkg.generate(clapper_plugin, install_dir: libdir + '/pkgconfig')
 endif
 
 subdir('handlers')

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -253,7 +253,7 @@ cdata.set('DISABLE_ORC', 1)
 cdata.set('GST_ENABLE_EXTRA_CHECKS', get_option('devel-checks'))
 
 configinc = include_directories('.')
-libsinc = include_directories('gst')
+libsinc = include_directories('gst/clapper')
 
 gir = find_program('g-ir-scanner', required: false)
 gir_init_section = ['--add-init-section=extern void gst_init(gint*,gchar**);' + \

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -48,9 +48,6 @@ else
   export_define = 'extern'
 endif
 
-# Passing this through the command line would be too messy
-cdata.set('GST_API_EXPORT', export_define)
-
 # Disable strict aliasing
 if cc.has_argument('-fno-strict-aliasing')
   add_project_arguments('-fno-strict-aliasing', language: 'c')

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('com.github.rafostar.Clapper', 'c', 'cpp',
+project('clapper', 'c', 'cpp',
   version: '0.5.2',
   meson_version: '>= 0.50.0',
   license: 'GPL-3.0-or-later',


### PR DESCRIPTION
- Make build output pkgconfig files
- Fix wrong bracket when building with egl support only
- Fix header outputs